### PR TITLE
Calculate sha256 HMAC instead of sha1 HMAC

### DIFF
--- a/lib/HPP.js
+++ b/lib/HPP.js
@@ -2,8 +2,7 @@
 
 // TODO: Custom Payment method
 
-// var crypto = require('crypto');
-var cryptojs = require('crypto-js');
+var crypto = require('crypto');
 var zlib = require('zlib');
 var moment = require('moment');
 
@@ -92,40 +91,37 @@ HPP.prototype.generateHash = function () {
   var hmac;
   var hmacText;
   var key;
+  var self = this;
+  var keys = [];
 
   for (key in this._request) {
-    if (this._request.hasOwnProperty(key) || this._request[key]) {
-      hmacText += this._request[key];
+    if (this._request.hasOwnProperty(key) && this._request[key]) {
+      keys.push(key);
     }
   }
 
-  // Required fields
-  hmacText =
-      this._request.paymentAmount +
-      this._request.currencyCode +
-      this._request.shipBeforeDate +
-      this._request.merchantReference +
-      this._request.skinCode +
-      this._request.merchantAccount +
-      this._request.sessionValidity;
+  keys.sort();
 
-  // Optional fields
-  hmacText += this._request.shopperEmail || '';
-  hmacText += this._request.shopperReference || '';
-  hmacText += this._request.recurringContract || '';
-  hmacText += this._request.allowedMethods || '';
-  hmacText += this._request.blockedMethods || '';
-  hmacText += this._request.shopperStatement || '';
-  hmacText += this._request.merchantReturnData || '';
-  hmacText += this._request.offset || '';
+  hmacText = [];
 
-  // hmac = crypto.createHmac('sha1', this._HMACKey);
-  // hmac.update(hmacText);
+  // Add keys
+  keys.forEach(function(key){
+    hmacText.push(key); 
+  });
 
-  hmac = cryptojs.HmacSHA256(hmacText, this._HMACKey);
+  // Add values
+  keys.forEach(function(key){
+    var val = '' + self._request[key];
+    hmacText.push(val.replace(/\\/g, '\\\\').replace(/:/g, '\\:'));
+  });
 
-  // this._request.merchantSig = hmac.digest('base64');
-  this._request.merchantSig = hmac.toString(cryptojs.enc.Base64);
+  var buffer = new Buffer(this._HMACKey, 'hex');
+
+  hmacText = hmacText.join(':');
+  hmac = crypto.createHmac('sha256', buffer);
+  hmac.update(hmacText);
+
+  this._request.merchantSig = hmac.digest('base64');
 };
 
 HPP.prototype.generateRequest = function (callback) {

--- a/lib/HPP.js
+++ b/lib/HPP.js
@@ -2,7 +2,8 @@
 
 // TODO: Custom Payment method
 
-var crypto = require('crypto');
+// var crypto = require('crypto');
+var cryptojs = require('crypto-js');
 var zlib = require('zlib');
 var moment = require('moment');
 
@@ -118,10 +119,13 @@ HPP.prototype.generateHash = function () {
   hmacText += this._request.merchantReturnData || '';
   hmacText += this._request.offset || '';
 
-  hmac = crypto.createHmac('sha1', this._HMACKey);
-  hmac.update(hmacText);
+  // hmac = crypto.createHmac('sha1', this._HMACKey);
+  // hmac.update(hmacText);
 
-  this._request.merchantSig = hmac.digest('base64');
+  hmac = cryptojs.HmacSHA256(hmacText, this._HMACKey);
+
+  // this._request.merchantSig = hmac.digest('base64');
+  this._request.merchantSig = hmac.toString(cryptojs.enc.Base64);
 };
 
 HPP.prototype.generateRequest = function (callback) {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "author": "Péter Márton, @slashdotpeter",
   "dependencies": {
+    "crypto-js": "^3.1.5",
     "moment": "~2.10.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adyen",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "NodeJS module for the Adyen payment provider",
   "main": "./lib/adyen",
   "scripts": {
@@ -11,7 +11,6 @@
   },
   "author": "Péter Márton, @slashdotpeter",
   "dependencies": {
-    "crypto-js": "^3.1.5",
     "moment": "~2.10.3"
   },
   "devDependencies": {


### PR DESCRIPTION
After july 1th 2016 (tomorrow) Adyen will only accept sha256 HMAC
