### PR TITLE
Made generateRequest method to provide all payment details

### DIFF
--- a/lib/HPP.js
+++ b/lib/HPP.js
@@ -106,7 +106,7 @@ HPP.prototype.generateHash = function () {
 
   // Add keys
   keys.forEach(function(key){
-    hmacText.push(key); 
+    hmacText.push(key);
   });
 
   // Add values
@@ -149,7 +149,7 @@ HPP.prototype.generateRequest = function (callback) {
       }
     }
 
-    return callback(null, requestUrl, _this._request.merchantReference);
+    return callback(null, requestUrl, _this._request);
   });
 };
 

--- a/test/hpp.js
+++ b/test/hpp.js
@@ -44,12 +44,12 @@ describe('HPP', function () {
       expect(validate).to.throw(Error);
     });
 
-    it('should generate url and merchantReference', function (done) {
-      hppPayment.generateRequest(function (err, url, merchantReference) {
+    it('should generate url and paymentData', function (done) {
+      hppPayment.generateRequest(function (err, url, paymentData) {
         expect(url).to.be.a('string');
-        expect(merchantReference).to.be.a('string');
-        expect(merchantReference).to.have.string('PAYMENT-');
-
+        expect(paymentData).to.be.a('object');
+        expect(paymentData.merchantReference).to.have.string('PAYMENT-');
+        
         expect(url).to.match(/((http|https):\/\/(\w+:{0,1}\w*@)?(\S+)|)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?/);
 
         expect(url).to.contain('JessePiscaerCOM');


### PR DESCRIPTION
Made the `HPP.generateRequest()` to return paymentURL as well as the entire `paymentData`, currently we get the payment data by using `url.query`, with this change we can get the `paymentData.merchantReferance` and more.