### PR TITLE
Losen version constraints

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
   },
   "author": "Péter Márton, @slashdotpeter",
   "dependencies": {
-    "moment": "~2.10.3"
+    "moment": "^2.10.3"
   },
   "devDependencies": {
-    "mocha": "~2.2.5",
-    "chai": "~3.0.0"
+    "mocha": "^2.2.5",
+    "chai": "^3.0.0"
   }
 }


### PR DESCRIPTION
When using this library as dependency with yarn (or npm 5), it would be nice to not be restricted to using `moment@2.10.6` at most.